### PR TITLE
Allow source language input to be blank for DeepL language auto-detection (#28)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,8 +138,8 @@ function setLanguage() {
     if (
       !availableLocaleSource
         .map((langObj) => langObj.language)
-        .includes(responseSourceLocale) ||
-      responseSourceLocale === ''
+        .includes(responseSourceLocale) &&
+      responseSourceLocale != ''
     ) {
       throw new Error(
         `[${ADDON_NAME}] Invalid Value (${responseSourceLocale}): Enter a valid value.`


### PR DESCRIPTION
Fix #28 