### PR TITLE
Update error message for cells with too much text

### DIFF
--- a/src/sheetsl.ts
+++ b/src/sheetsl.ts
@@ -290,9 +290,15 @@ export function translateRange(): void {
         if (cellValue === '') {
           return '';
         }
-        if (getBlobBytes(encodeURIComponent(cellValue)) > THRESHOLD_BYTES) {
+        const textBytes = getBlobBytes(encodeURIComponent(cellValue));
+        if (textBytes > THRESHOLD_BYTES) {
+          const cellValueString = cellValue.toString();
+          const truncatedCellValue = cellValueString.slice(
+            0,
+            Math.floor((cellValueString.length * THRESHOLD_BYTES) / textBytes)
+          );
           throw new Error(
-            `[${ADDON_NAME}] Cell content is too long. Please consider splitting the content into multiple cells:\n${cellValue}`
+            `[${ADDON_NAME}] Cell content length exceeds Google's limits. Please consider splitting the content into multiple cells. The following is the estimated maximum length of the cell in question:\n${truncatedCellValue}\n\nPlease note that this is a rough estimate and that the exact acceptable text length might differ slightly.`
           );
         } else {
           Utilities.sleep(1000); // Interval to avoid concentrated access to API

--- a/src/sheetsl.ts
+++ b/src/sheetsl.ts
@@ -298,7 +298,7 @@ export function translateRange(): void {
             Math.floor((cellValueString.length * THRESHOLD_BYTES) / textBytes)
           );
           throw new Error(
-            `[${ADDON_NAME}] Cell content length exceeds Google's limits. Please consider splitting the content into multiple cells. The following is the estimated maximum length of the cell in question:\n${truncatedCellValue}\n\nPlease note that this is a rough estimate and that the exact acceptable text length might differ slightly.`
+            `[${ADDON_NAME}] Cell content length exceeds Google's limits. Please consider splitting the content into multiple cells. The following is the estimated maximum length of the cell in question:\n${truncatedCellValue}\n\nPlease note that this is a rough estimate and that the actual acceptable text length might differ slightly.`
           );
         } else {
           Utilities.sleep(1000); // Interval to avoid concentrated access to API


### PR DESCRIPTION
This pull request resolves #75 by informing the user of a rough estimate of the optimal text length in the error message.

### Original Message

> [SheetsL] Cell content is too long. Please consider splitting the content into multiple cells:
> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

### Updated Message

> [SheetsL] Cell content length exceeds Google's limits. Please consider splitting the content into multiple cells. The following is the estimated maximum length of the cell in question:
> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
> 
> Please note that this is a rough estimate and that the actual acceptable text length might differ slightly.